### PR TITLE
Python 2 compatibility

### DIFF
--- a/pypugjs/ext/django/loader.py
+++ b/pypugjs/ext/django/loader.py
@@ -51,7 +51,8 @@ class Loader(BaseLoader):
                     contents = origin.loader.get_contents(origin)
                     contents = self.include_pug_sources(contents)
                     contents = process(contents, filename=origin.template_name, compiler=Compiler)
-                except IOError:
+                # TODO: Change IOError to FileNotFoundError after future==0.17.0
+                except IOError as err:
                     raise TemplateDoesNotExist(origin)
             else:
                 contents = origin.loader.get_contents(origin)

--- a/pypugjs/ext/django/loader.py
+++ b/pypugjs/ext/django/loader.py
@@ -51,7 +51,7 @@ class Loader(BaseLoader):
                     contents = origin.loader.get_contents(origin)
                     contents = self.include_pug_sources(contents)
                     contents = process(contents, filename=origin.template_name, compiler=Compiler)
-                except FileNotFoundError:
+                except IOError:
                     raise TemplateDoesNotExist(origin)
             else:
                 contents = origin.loader.get_contents(origin)


### PR DESCRIPTION
As discussed, use IOError instead of FileNotFoundError (for now)
added a TODO so we can use the FileNotFoundError from future module in the future
@kakulukia please kindly take a look at this