### PR TITLE
Update jinja.py

### DIFF
--- a/pypugjs/ext/jinja.py
+++ b/pypugjs/ext/jinja.py
@@ -119,7 +119,8 @@ class PyPugJSExtension(Extension):
             loader = loader.app.jinja_loader
         except AttributeError:
             pass
-        self.options["basedir"] = loader.searchpath[0]
+        if len(loader.searchpath):
+            self.options["basedir"] = loader.searchpath[0]
 
         if (not name or
                 (name and not os.path.splitext(name)[1] in self.file_extensions)):


### PR DESCRIPTION
It's possible that the loader doesn't have a searchpath, for example when using pyramid_jinja2's SmartAssetSpecLoader https://docs.pylonsproject.org/projects/pyramid_jinja2/en/latest/api.html#pyramid_jinja2.SmartAssetSpecLoader