### PR TITLE
Clean pipe inserts whitespace

### DIFF
--- a/pypugjs/lexer.py
+++ b/pypugjs/lexer.py
@@ -62,7 +62,7 @@ class Lexer(object):
     RE_DOCTYPE = re.compile(r'^(?:!!!|doctype) *([^\n]+)?')
     RE_ID = re.compile(r'^#([\w-]+)')
     RE_CLASS = re.compile(r'^\.([\w-]+)')
-    RE_STRING = re.compile(r'^(?:\| ?)([^\n]+)')
+    RE_STRING = re.compile(r'^(?:\| ?)([^\n]*)')
     RE_TEXT = re.compile(r'^([^\n]+)')
     RE_EXTENDS = re.compile(r'^extends? +([^\n]+)')
     RE_PREPEND = re.compile(r'^prepend +([^\n]+)')

--- a/pypugjs/testsuite/cases/text.html
+++ b/pypugjs/testsuite/cases/text.html
@@ -2,6 +2,8 @@
 <p>foo
 bar
 baz
+
+bazar
 </p>
 <p>foo
 

--- a/pypugjs/testsuite/cases/text.pug
+++ b/pypugjs/testsuite/cases/text.pug
@@ -4,7 +4,8 @@ p
   | foo
   | bar
   | baz
-
+  |
+  | bazar
 p.
   foo
 


### PR DESCRIPTION
This allows for use of a single pipe character on a line to insert a whitespace before or after a tag.
See issue #13 I guess?