### PR TITLE
Fix nested arrays

### DIFF
--- a/pypugjs/runtime.py
+++ b/pypugjs/runtime.py
@@ -129,7 +129,8 @@ def iteration(obj, num_keys):
         return []
 
     if is_iterable(head):
-        if num_keys == get_cardinality(head) + 1:
+        cardinality = get_cardinality(head)
+        if cardinality > 0 and num_keys == cardinality + 1:
             return (tuple(item) + (ix,) for ix, item in enumerate(iter_obj))
         else:
             return iter_obj

--- a/pypugjs/testsuite/test_runtime.py
+++ b/pypugjs/testsuite/test_runtime.py
@@ -30,3 +30,7 @@ class TestIteration(object):
         test_list = [1, 2]
         iterator = iter(test_list)
         assert list(runtime.iteration(iterator, 1)) == test_list
+
+    def test_nested_empty_array_with_single_key(self):
+        test_list = [[]]
+        assert list(runtime.iteration(test_list, 1)) == test_list


### PR DESCRIPTION
I've recently discovered that nested empty lists will either be rendered as 0, 1, 2 or fail (depending on the actual code). Also a code like this:

```
-for field in form:
    != field
```

May not work as expected when the first field is iterable and produces zero results (like empty `ChoiceField` in django)