### PR TITLE
Add docs to sdist tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft docs


### PR DESCRIPTION
Adds `MANIFEST.in` which tells setuptools to add the docs directory to the sdist tarball. This makes it possible to install the package from the `sdist` source tarball. I have tested that this PR allows the source tarball to be used to install the package.