### PR TITLE
Fix deprecation warning

### DIFF
--- a/pypugjs/runtime.py
+++ b/pypugjs/runtime.py
@@ -9,7 +9,7 @@ from chardet.universaldetector import UniversalDetector
 import io
 
 try:
-    from collections import Mapping as MappingType
+    from collections.abc import Mapping as MappingType
 except ImportError:
     import UserDict
 


### PR DESCRIPTION
Fix deprecation warning
```
  /usr/local/lib/python3.8/site-packages/pypugjs/runtime.py:12: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping as MappingType
```