### PR TITLE
Removed Quotation overwrite of tag attributes to allow using json in tag attributes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypugjs"
-version = "5.9.13"
+version = "5.9.12"
 description = ""
 authors = ["Andy Grabow <andy@freilandkiwis.de>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypugjs"
-version = "5.9.4"
+version = "5.9.13"
 description = ""
 authors = ["Andy Grabow <andy@freilandkiwis.de>"]
 license = "MIT"

--- a/pypugjs/nodes.py
+++ b/pypugjs/nodes.py
@@ -181,8 +181,8 @@ class Tag(Node):
             name = attr['name']
             val = attr['val']
             static = attr['static']  # and isinstance(val,six.string_types)
-            #if static:
-            #    val = self.static(val)
+            if static:
+                val = self.static(val)
             if val in ("True", "False", "None"):
                 val = val == "True"
                 static = True

--- a/pypugjs/nodes.py
+++ b/pypugjs/nodes.py
@@ -177,8 +177,8 @@ class Tag(Node):
             name = attr['name']
             val = attr['val']
             static = attr['static']  # and isinstance(val,six.string_types)
-            if static:
-                val = self.static(val)
+            #if static:
+            #    val = self.static(val)
             if val in ("True", "False", "None"):
                 val = val == "True"
                 static = True

--- a/pypugjs/nodes.py
+++ b/pypugjs/nodes.py
@@ -146,12 +146,16 @@ class Tag(Node):
         if not isinstance(string, six.string_types) or not string:
             return string
         if string[0] in ('"', "'"):
-            if string[0] == string[-1]:
+            if string[0] == string[-1] and not ("'" in string and '"' in string):
+                # string is enclosed in quotes AND has no other quotes inside -> we make the string raw
                 string = string[1:-1]
             else:
+                # contains both types of quotes OR is asymmetrically quoted, we may not change the string
                 return string
         if only_remove:
+            # return raw string
             return string
+        # string is now raw, we need to quote it
         return '"%s"' % string
 
     def setAttribute(self, name, val, static=True):

--- a/pypugjs/testsuite/cases/attr-with-json.html
+++ b/pypugjs/testsuite/cases/attr-with-json.html
@@ -1,0 +1,1 @@
+<div hx-target="#container" hx-headers='{"myHeader": "My Value"}' class="col col-4"></div>

--- a/pypugjs/testsuite/cases/attr-with-json.pug
+++ b/pypugjs/testsuite/cases/attr-with-json.pug
@@ -1,0 +1,1 @@
+.col(class='col-4' hx-target='#container' hx-headers='{"myHeader": "My Value"}')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.9.13
+current_version = 5.9.12
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.9.12
+current_version = 5.9.13
 commit = True
 tag = True
 


### PR DESCRIPTION
To be completely honest, i have hardly an idea on the intention of the "static attribute" thing, but disabling it seems to resolve the issue:
https://github.com/stheid/pypugjs/blob/6445868fe81c883fe28f34366fe35e0869b780f4/pypugjs/nodes.py#L179-L182

This part however needs to remain:
https://github.com/stheid/pypugjs/blob/6445868fe81c883fe28f34366fe35e0869b780f4/pypugjs/nodes.py#L191-L201

test.pug
```
.red(class='blue' hx-headers='{"myHeader": "My Value"}')
```

result.html
```
<div hx-headers='{"myHeader": "My Value"}' class="red blue"></div>
```