### PR TITLE
Move test dependencies to dev-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,23 +7,21 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.8"
+charset-normalizer = "^2.1.0"
+six = "^1.15.0"
+
+[tool.poetry.group.dev.dependencies]
+coverage = "^6.3.2"
+Django = "^4.0.6"
+flake8 = "^4.0.1"
+Flask = "^2.1.1"
+icecream = "^2.1.3"
 Jinja2 = "^3.1.1"
 Mako = "^1.1.3"
-tornado = "^6.0.4"
-six = "^1.15.0"
-coverage = "^6.3.2"
-Flask = "^2.1.1"
-charset-normalizer = "^2.1.0"
-flake8 = "^4.0.1"
 pytest = "^7.1.2"
 pytest-asyncio = "^0.19.0"
 pytest-cov = "^3.0.0"
-
-[tool.poetry.dev-dependencies]
-
-[tool.poetry.group.dev.dependencies]
-icecream = "^2.1.3"
-Django = "^4.0.6"
+tornado = "^6.0.4"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Move dependencies that are used only when running tests / doing development to `dev-dependencies`.  Otherwise, Poetry creates unconditional dependency on these packages (such as `pytest-cov`), and they would be incorrectly installed into the production environment, e.g. when issuing `pip install git+https://github.com/kakolukia/pypugjs`.