### PR TITLE
Fix escape filter precedence in interpolation and visitVar

### DIFF
--- a/pypugjs/ext/jinja.py
+++ b/pypugjs/ext/jinja.py
@@ -107,6 +107,40 @@ class Compiler(_Compiler):
                 if codeTag in self.auto_close_code:
                     self.buf.append('{%% end%s %%}' % codeTag)
 
+    def interpolate(self, text, escape=None):
+        def repl(matchobj):
+            if escape is None:
+                if matchobj.group(2) == '!':
+                    filter_string = ''
+                else:
+                    filter_string = '|escape'
+            else:
+                if escape is True:
+                    filter_string = '|escape'
+                else:
+                    filter_string = ''
+
+            matchvar = matchobj.group(3)
+            if (matchvar[0] in ['"', "'"]
+                    and matchvar[-1] == matchvar[0]
+                    and filter_string == '|escape'):
+                return self.html_escape(matchvar[1:-1])
+
+            if filter_string:
+                # Parentheses ensure |escape applies to the whole expression,
+                # not just the last operand (e.g. `a - 10|escape` escapes
+                # only 10 and causes a TypeError on the subtraction)
+                matchvar = '(%s)' % matchvar
+
+            return (
+                self.variable_start_string
+                + matchvar
+                + filter_string
+                + self.variable_end_string
+            )
+
+        return self.RE_INTERPOLATE.sub(repl, text)
+
     def visitEach(self, each):
         self.buf.append(
             "{%% for %s in %s(%s,%d) %%}"

--- a/pypugjs/testsuite/test_jinja_escape.py
+++ b/pypugjs/testsuite/test_jinja_escape.py
@@ -1,9 +1,19 @@
 """Test that the Jinja2 |escape filter applies to the full expression.
 
-Regression test for a bug where `= expr or fallback` compiled to
-``{{ expr or fallback|escape }}``.  Due to Jinja2 filter precedence,
-|escape only bound to `fallback`, leaving `expr` unescaped (XSS).
-The fix wraps the expression in parentheses: ``{{ (expr or fallback)|escape }}``.
+Regression tests for two related bugs where |escape was appended as a raw
+suffix, causing Jinja2 filter precedence to bind it to the wrong operand:
+
+1. Buffered code: `= expr or fallback` compiled to
+   ``{{ expr or fallback|escape }}`` — |escape only bound to `fallback`.
+   (Fixed in visitCode, PR #90.)
+
+2. Interpolation: `#{a - 10}` compiled to
+   ``{{ a - 10|escape }}`` — |escape bound to `10`, producing a Markup
+   string, so the subtraction became `int - Markup` (TypeError).
+   (Fixed in interpolate.)
+
+The fix wraps the expression in parentheses so |escape applies to the
+entire result.
 """
 
 from jinja2 import Environment
@@ -22,8 +32,8 @@ def _render(template_str: str, **ctx) -> str:
     return env.from_string(template_str).render(**ctx)
 
 
-class TestEscapeFilterPrecedence:
-    """Ensure |escape applies to the whole expression, not just the last operand."""
+class TestBufferedCodeEscape:
+    """Ensure |escape applies to the whole expression in `= expr` output."""
 
     def test_simple_expression(self):
         result = _compile('p= text')
@@ -55,3 +65,41 @@ class TestEscapeFilterPrecedence:
         result = _compile('- x = 1')
         assert '{%' in result
         assert '|escape' not in result
+
+
+class TestInterpolationEscape:
+    """Ensure |escape applies to the whole expression in #{} interpolation."""
+
+    def test_subtraction(self):
+        result = _compile('p #{a - 10} more')
+        assert '(a - 10)|escape' in result
+
+    def test_or_expression(self):
+        result = _compile('p #{a or b}')
+        assert '(a or b)|escape' in result
+
+    def test_simple_var(self):
+        result = _compile('p #{name}')
+        assert '(name)|escape' in result
+
+    def test_subtraction_renders_correctly(self):
+        compiled = _compile('p #{a - 10} more')
+        html = _render(compiled, a=42)
+        assert '32 more' in html
+
+    def test_interpolation_xss(self):
+        compiled = _compile('p #{a or b}')
+        html = _render(compiled, a='<script>xss</script>', b='safe')
+        assert '&lt;script&gt;' in html
+        assert '<script>' not in html
+
+    def test_unescaped_interpolation(self):
+        """!{} should not add |escape or parentheses."""
+        result = _compile('p !{a - 10}')
+        assert '|escape' not in result
+        assert 'a - 10' in result
+
+    def test_multiple_interpolations(self):
+        result = _compile('p #{a + b} and #{c - d}')
+        assert '(a + b)|escape' in result
+        assert '(c - d)|escape' in result


### PR DESCRIPTION
The previous fix (PR #90) addressed the escape precedence bug in visitCode (buffered code like `= expr or fallback`), but the same bug existed in two other code paths:

1. interpolate(): `#{a - 10}` compiled to `{{ a - 10|escape }}`. Due to Jinja2 filter precedence, |escape bound only to `10`, producing Markup('10'). The subtraction then failed with `TypeError: unsupported operand type(s) for -: 'int' and 'Markup'`.

2. visitVar(): same raw `|escape` suffix without parentheses. Currently not reachable with escape=True from the Jinja2 compiler (which overrides visitCode), but other template backends that use the base compiler's visitCode → visitVar chain are affected.

Fix: wrap the expression in parentheses before appending |escape, consistent with the visitCode fix from PR #90.